### PR TITLE
Add main branch merge protection workflow

### DIFF
--- a/.github/workflows/merge-protect.yml
+++ b/.github/workflows/merge-protect.yml
@@ -1,0 +1,14 @@
+name: 'Merge Protect'
+
+on:
+  pull_request:
+
+jobs:
+  check_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch
+        if: github.base_ref == 'main' && github.head_ref != 'main-preview'
+        run: |
+          echo "ERROR: You can only merge to main from main-preview."
+          exit 1


### PR DESCRIPTION
All merges to main must come from the main-preview branch, to ensure that code is properly merged on main-preview before being pushed to production.

This is enforced through a new GitHub workflow.